### PR TITLE
Search

### DIFF
--- a/public/src/modules/topicList.js
+++ b/public/src/modules/topicList.js
@@ -69,10 +69,22 @@ define('topicList', [
         hooks.fire('action:topics.loaded', { topics: ajaxify.data.topics });
     };
 
+    function resetSearch(topics, replace, callback) {
+        callback = callback || function () { };
+        app.parseAndTranslate('partials/topics_list', 'topics', { topics: topics }, function (html) {
+            $('.topic-list')[replace ? 'html' : 'append'](html);
+            utils.makeNumbersHumanReadable(html.find('.human-readable-number'));
+            callback();
+        });
+    }
+
     function handleSearch() {
         $('#post-search').on('input propertychange', utils.debounce(async function () {
             const query = $('#post-search').val();
             const allTopics = ajaxify.data.topics;
+            if (!query.length) {
+                resetSearch(allTopics, true);
+            }
             const subTopics = [];
             allTopics.forEach((t) => {
                 if (t.title == query) {
@@ -82,15 +94,6 @@ define('topicList', [
             onSearchLoaded(subTopics, true);
         }, 250));
 
-    }
-    
-    function onSearchLoaded(topics, replace, callback) {
-        callback = callback || function () { };
-        app.parseAndTranslate('partials/topics_list', 'topics', { topics: topics }, function (html) {
-            $('.topic-list')[replace ? 'html' : 'append'](html);
-            utils.makeNumbersHumanReadable(html.find('.human-readable-number'));
-            callback();
-        });
     }
 
     function findTopicListElement() {

--- a/public/src/modules/topicList.js
+++ b/public/src/modules/topicList.js
@@ -69,14 +69,7 @@ define('topicList', [
         hooks.fire('action:topics.loaded', { topics: ajaxify.data.topics });
     };
 
-    function resetSearch(topics, replace, callback) {
-        callback = callback || function () { };
-        app.parseAndTranslate('partials/topics_list', 'topics', { topics: topics }, function (html) {
-            $('.topic-list')[replace ? 'html' : 'append'](html);
-            utils.makeNumbersHumanReadable(html.find('.human-readable-number'));
-            callback();
-        });
-    }
+    
 
     function handleSearch() {
         $('#post-search').on('input propertychange', utils.debounce(async function () {
@@ -94,6 +87,15 @@ define('topicList', [
             onSearchLoaded(subTopics, true);
         }, 250));
 
+    }
+    
+    function onSearchLoaded(topics, replace, callback) {
+        callback = callback || function () { };
+        app.parseAndTranslate('partials/topics_list', 'topics', { topics: topics }, function (html) {
+            $('.topic-list')[replace ? 'html' : 'append'](html);
+            utils.makeNumbersHumanReadable(html.find('.human-readable-number'));
+            callback();
+        });
     }
 
     function findTopicListElement() {

--- a/public/src/modules/topicList.js
+++ b/public/src/modules/topicList.js
@@ -79,9 +79,18 @@ define('topicList', [
                     subTopics.push(t);
                 }
             })
-            
+            onSearchLoaded(subTopics, true);
         }, 250));
 
+    }
+    
+    function onSearchLoaded(topics, replace, callback) {
+        callback = callback || function () { };
+        app.parseAndTranslate('partials/topics_list', 'topics', { topics: topics }, function (html) {
+            $('.topic-list')[replace ? 'html' : 'append'](html);
+            utils.makeNumbersHumanReadable(html.find('.human-readable-number'));
+            callback();
+        });
     }
 
     function findTopicListElement() {

--- a/public/src/modules/topicList.js
+++ b/public/src/modules/topicList.js
@@ -26,6 +26,7 @@ define('topicList', [
 
     TopicList.init = function (template, cb) {
         topicListEl = findTopicListElement();
+        handleSearch();
 
         templateName = template;
         loadTopicsCallback = cb || loadTopicsAfter;
@@ -67,6 +68,21 @@ define('topicList', [
 
         hooks.fire('action:topics.loaded', { topics: ajaxify.data.topics });
     };
+
+    function handleSearch() {
+        $('#post-search').on('input propertychange', utils.debounce(async function () {
+            const query = $('#post-search').val();
+            const allTopics = ajaxify.data.topics;
+            const subTopics = [];
+            allTopics.forEach((t) => {
+                if (t.title == query) {
+                    subTopics.push(t);
+                }
+            })
+            
+        }, 250));
+
+    }
 
     function findTopicListElement() {
         return $('[component="category"]').filter(function (i, e) {

--- a/src/topicList.js
+++ b/src/topicList.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../public/src/modules/topicList');

--- a/test/topiclists.js
+++ b/test/topiclists.js
@@ -1,0 +1,91 @@
+'use strict';
+
+global.define = () => null;
+const async = require('async');
+const path = require('path');
+const assert = require('assert');
+const validator = require('validator');
+const mockdate = require('mockdate');
+const nconf = require('nconf');
+const request = require('request');
+const util = require('util');
+
+const sleep = util.promisify(setTimeout);
+
+const db = require('./mocks/databasemock');
+const file = require('../src/file');
+const topics = require('../src/topics');
+const posts = require('../src/posts');
+const categories = require('../src/categories');
+const privileges = require('../src/privileges');
+const meta = require('../src/meta');
+const User = require('../src/user');
+const groups = require('../src/groups');
+const helpers = require('./helpers');
+const socketPosts = require('../src/socket.io/posts');
+const socketTopics = require('../src/socket.io/topics');
+const apiTopics = require('../src/api/topics');
+const topicList = require('../src/topicList');
+
+describe('TopicList\'s', () => {
+    let topic;
+    let categoryObj;
+    let adminUid;
+    let adminJar;
+    let csrf_token;
+    let fooUid;
+
+    before(async () => {
+        adminUid = await User.create({ username: 'admin', password: '123456' });
+        fooUid = await User.create({ username: 'foo' });
+        await groups.join('administrators', adminUid);
+        const adminLogin = await helpers.loginUser('admin', '123456');
+        adminJar = adminLogin.jar;
+        csrf_token = adminLogin.csrf_token;
+
+        categoryObj = await categories.create({
+            name: 'Test Category',
+            description: 'Test category created by testing script',
+        });
+        topic = {
+            userId: adminUid,
+            categoryId: categoryObj.cid,
+            title: 'Test Topic Title',
+            content: 'The content of test topic',
+        };
+    });
+
+    describe('handleSearch', () => {
+        let topic1;
+        let topic2;
+        before((done) => {
+            async.series([
+                function (next) {
+                    topics.post({ uid: adminUid, title: 'topic 1', content: 'content 1', cid: categoryObj.cid }, next);
+                },
+                function (next) {
+                    topics.post({ uid: adminUid, title: 'topic 2', content: 'content 2', cid: categoryObj.cid }, next);
+                },
+            ], (err, results) => {
+                assert.ifError(err);
+                topic1 = results[0];
+                topic2 = results[1];
+                done();
+            });
+        });
+
+        after((done) => {
+            meta.config.teaserPost = '';
+            done();
+        });
+
+        it('should return empty array if query doesnt match any topic titles',
+            (done) => {
+                topicList.handleSearch('topic 3', (err, topics) => {
+                    assert.ifError(err);
+                    assert.equal(0, topics.length);
+                    done();
+                });
+            });
+    });
+});

--- a/themes/nodebb-theme-persona/templates/category.tpl
+++ b/themes/nodebb-theme-persona/templates/category.tpl
@@ -22,6 +22,7 @@
             </a>
 
             <span class="pull-right" component="category/controls">
+                <!-- IMPORT partials/category/search.tpl -->
                 <!-- IMPORT partials/category/watch.tpl -->
                 <!-- IMPORT partials/category/sort.tpl -->
                 <!-- IMPORT partials/category/tools.tpl -->

--- a/themes/nodebb-theme-persona/templates/partials/category/search.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/category/search.tpl
@@ -1,3 +1,8 @@
-<div>
-    <input class="title form-control" type="text" placeholder="Search announcement">
+<div class="row">
+    <div class="col-lg-12">
+        <div class="input-group">
+            <input type="text" class="form-control" placeholder="[[global:search]]" id="post-search">
+            <span class="input-group-addon search-button"><i class="fa fa-search"></i></span>
+        </div>
+    </div>
 </div>

--- a/themes/nodebb-theme-persona/templates/partials/category/search.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/category/search.tpl
@@ -1,0 +1,3 @@
+<div>
+    <input class="title form-control" type="text" placeholder="Search announcement">
+</div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,10 @@
   },
   "include": [
     "public/src/**/*",
-    "src/**/*", 
+    "src/**/*",
     "test/**/*",
   ],
-  "exclude":[
+  "exclude": [
     "node_modules",
   ]
 }


### PR DESCRIPTION
resolves #11 
What: Added search backend logic that filters all topics by title and connects to the UI by only displaying ones that match the query. 
Why: Allows users to quickly find announcements by title
How: Clone this branch, navigate to the announcements page, and type something into the search bar
Testing: I manually tested it and also wrote test cases. The test cases are in a separate branch because I could not get the handleSearch function to export properly in the test suite. I worked with the TAs in OH for several hours and could not arrive at a solution.