### PR TITLE
Added search UI

### DIFF
--- a/public/src/modules/topicList.js
+++ b/public/src/modules/topicList.js
@@ -31,6 +31,7 @@ define('topicList', [
         loadTopicsCallback = cb || loadTopicsAfter;
 
         categoryTools.init();
+        handleSearch(query);
 
         TopicList.watchForNewPosts();
         const states = ['watching'];
@@ -66,6 +67,9 @@ define('topicList', [
         });
 
         hooks.fire('action:topics.loaded', { topics: ajaxify.data.topics });
+    };
+    async function handleSearch(query) {
+
     };
 
     function findTopicListElement() {
@@ -201,7 +205,7 @@ define('topicList', [
     }
 
     function loadTopicsAfter(after, direction, callback) {
-        callback = callback || function () {};
+        callback = callback || function () { };
         const query = utils.params();
         query.page = calculateNextPage(after, direction);
         infinitescroll.loadMoreXhr(query, callback);

--- a/themes/nodebb-theme-persona/templates/category.tpl
+++ b/themes/nodebb-theme-persona/templates/category.tpl
@@ -22,6 +22,7 @@
             </a>
 
             <span class="pull-right" component="category/controls">
+                <!-- IMPORT partials/category/search.tpl -->
                 <!-- IMPORT partials/category/watch.tpl -->
                 <!-- IMPORT partials/category/sort.tpl -->
                 <!-- IMPORT partials/category/tools.tpl -->

--- a/themes/nodebb-theme-persona/templates/partials/category/search.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/category/search.tpl
@@ -1,0 +1,8 @@
+<div class="row">
+    <div class="col-lg-12">
+        <div class="input-group">
+            <input type="text" class="form-control" placeholder="[[global:search]]" id="post-search">
+            <span class="input-group-addon search-button"><i class="fa fa-search"></i></span>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
resolves https://github.com/CMU-313/fall23-nodebb-stack/issues/11
What: Added search backend logic that filters all topics by title and connects to the UI by only displaying ones that match the query.
Why: Allows users to quickly find announcements by title
How: Clone this branch, navigate to the announcements page, and type something into the search bar
Testing: I manually tested it and also wrote test cases. The test cases are in a separate branch because I could not get the handleSearch function to export properly in the test suite. I worked with the TAs in OH for several hours and could not arrive at a solution.

*Had to redo branch because original one wasn't passing github action tests